### PR TITLE
feat: compatible with ie10+

### DIFF
--- a/styles/footer.css
+++ b/styles/footer.css
@@ -15,8 +15,9 @@ footer {
   padding: 42px 0;
   display: -webkit-flex;
   display: flex;
-  -webkit-flex: 0 980px;
-  flex: 0 980px;
+  /* "flex-shrink: 1" for IE10 */
+  -webkit-flex: 0 1 980px;
+  flex: 0 1 980px;
   -webkit-justify-content: center;
   justify-content: center
 }
@@ -119,8 +120,9 @@ footer {
 
 .copyright_legal_lang {
   padding: 12px 0;
-  -webkit-flex: 0 980px;
-  flex: 0 980px;
+  /* "flex-shrink: 1" for IE10 */
+  -webkit-flex: 0 1 980px;
+  flex: 0 1 980px;
   border-top: 1px solid #444
 }
 
@@ -179,6 +181,13 @@ footer {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box
+}
+
+/* "-ms-high-contrast: none" for IE10+ */
+@media screen and (-ms-high-contrast: none) {
+  .footer-wechat_qrcode, .switch-lang {
+    box-shadow: 0 5px 20px rgba(0, 0, 0, .2)
+  }
 }
 
 .switch-lang::before {

--- a/styles/header.css
+++ b/styles/header.css
@@ -20,6 +20,8 @@ header {
   width: 50px;
   height: 30px;
   margin-left: 32px;
+  /* "\9" for IE6-10 */
+  display: inline-block\9;
   background: url(../images/samadoyo.png) no-repeat center / contain
 }
 

--- a/styles/samadoyo.css
+++ b/styles/samadoyo.css
@@ -166,6 +166,7 @@ video:focus {
 }
 
 .model-list-items {
+  padding: 5px 0;
   -webkit-flex: 0 0 640px;
   flex: 0 0 640px;
   display: -webkit-flex;
@@ -177,7 +178,7 @@ video:focus {
 }
 
 .model-list-item {
-  margin-bottom: 10px
+  margin: 5px 0
 }
 
 .model-list-item a {
@@ -246,9 +247,10 @@ video:focus {
 }
 
 .poster-grid section {
-  max-width: 938px;
   min-width: 768px;
   margin: 48px auto;
+  -webkit-flex: 0 1 938px;
+  flex: 0 1 938px;
   display: -webkit-flex;
   display: flex;
   -webkit-flex-flow: row wrap;
@@ -331,6 +333,18 @@ video:focus {
   margin: 0 auto;
   -webkit-flex: 0 1 768px;
   flex: 0 1 768px
+}
+
+
+/* "-ms-high-contrast: none" for IE10+ */
+@media screen and (-ms-high-contrast: none) {
+  .about-content, .article {
+    margin: 0
+  }
+
+  .poster-grid section {
+    margin: 48px 0
+  }
 }
 
 .article-title {


### PR DESCRIPTION
### feat: compatible with ie10+ (#2)

- Fix logo cannot be displayed in IE10
- Fix hover shadow effect being blocked of model-list-item in IE
- Fix the alignment problem of all pages under "Understand Samadoyo" in IE10+ (Because the parent element use `justify-content: center` and the child elements also use `margin: 0 auto`.)
- Fix width will not shrink automatically of poster-grid and footer in IE10 (In IE10, if `flex-shrink` is not specified, it **defaults to 0, not 1**; So cancel the shorthand of `flex`)
- Use `box-shadow` in IE10+ that doesn't support the `filter: backdrop()`